### PR TITLE
Update deprecated method

### DIFF
--- a/imgbeddings/imgbeddings.py
+++ b/imgbeddings/imgbeddings.py
@@ -4,7 +4,7 @@ import random
 import itertools
 
 from transformers import CLIPProcessor
-from huggingface_hub import hf_hub_url, cached_download
+from huggingface_hub import hf_hub_url, hf_hub_download
 from onnxruntime import InferenceSession
 import numpy as np
 from tqdm.auto import tqdm
@@ -38,7 +38,7 @@ class imgbeddings:
             config_file_url = hf_hub_url(
                 repo_id="minimaxir/imgbeddings", filename=model_filename
             )
-            self.model_path = cached_download(
+            self.model_path = hf_hub_download(
                 config_file_url, force_filename=model_filename
             )
 
@@ -79,7 +79,7 @@ class imgbeddings:
             def batch(iterable, n=1):
                 length = len(iterable)
                 for ndx in range(0, length, n):
-                    yield iterable[ndx : min(ndx + n, length)]
+                    yield iterable[ndx: min(ndx + n, length)]
 
             embeddings = []
             pbar = tqdm(total=len(inputs), smoothing=0)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="imgbeddings",
     packages=["imgbeddings"],  # this must be the same as the name above
-    version="0.1.0",
+    version="0.1.1",
     description="A Python package to generate image embeddings with CLIP without PyTorch/TensorFlow",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
**Problem:** 
import of `imgbeddings` fails with an error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/denis/.pyenv/versions/torch/lib/python3.10/site-packages/imgbeddings/__init__.py", line 1, in <module>
    from .imgbeddings import imgbeddings  # noqa
  File "/home/denis/.pyenv/versions/torch/lib/python3.10/site-packages/imgbeddings/imgbeddings.py", line 7, in <module>
    from huggingface_hub import hf_hub_url, cached_download
ImportError: cannot import name 'cached_download' from 'huggingface_hub' (/home/denis/.pyenv/versions/torch/lib/python3.10/site-packages/huggingface_hub/__init__.py)
```

**Reason:**
Method `cached_download` was removed from `huggingface_hub` since version 0.26:  https://github.com/huggingface/huggingface_hub/pull/2579

**Solution:**
Use `hf_hub_download` instead of `cached_download`